### PR TITLE
Add ttk/style and tk/font to help with scaling issues.

### DIFF
--- a/pstk.scm
+++ b/pstk.scm
@@ -134,6 +134,7 @@
    tk/focus-follows-mouse
    tk/focus-next
    tk/focus-prev
+   tk/font
    tk/get-open-file
    tk/get-save-file
    tk/grab
@@ -205,6 +206,7 @@
   (define tk/focus-follows-mouse #f)
   (define tk/focus-next #f)
   (define tk/focus-prev #f)
+  (define tk/font #f)
   (define tk/get-open-file #f)
   (define tk/get-save-file #f)
   (define tk/grab #f)
@@ -877,6 +879,7 @@
     (set! tk/destroy (make-wish-func 'destroy))
     (set! tk/event (make-wish-func 'event))
     (set! tk/focus (make-wish-func 'focus))
+    (set! tk/font (make-wish-func 'font))
     (set! tk/grab (make-wish-func 'grab))
     (set! tk/grid (make-wish-func 'grid))
     (set! tk/image (make-wish-func 'image))


### PR DESCRIPTION
Tk notices when a screen is scaled and scales the default fonts automatically, if I understand correctly. Certainly, on scaled monitors the fonts are generally readable. Unfortunately, the style for the ttk::treeview does NOT automatically scale the rowheight needed, resulting in overlapping rows. To fix  that you have to manually get the linespace using the Tk command font and then update the Treeview style using ttk::style.

See the discussion of -rowheight in "STYLING OPTIONS" in the ttk::treeview documentation.